### PR TITLE
Prevent smiley pre-emption.

### DIFF
--- a/precise_bbcode/bbcode/parser.py
+++ b/precise_bbcode/bbcode/parser.py
@@ -411,7 +411,7 @@ class BBCodeParser(object):
             data = re.sub(url_re, linkrepl, data)
 
         if replace_smilies:
-            data = replace(data, self.smilies.items())
+            data = replace(data, sorted(self.smilies.items(), reverse=True))
 
         return data
 


### PR DESCRIPTION
This PR fixes #23 "Smiley Codes Can Pre-Empt Each Other." by ensuring that smilies are parsed longest-first.