### PR TITLE
Added multiple options for tags

### DIFF
--- a/precise_bbcode/bbcode/parser.py
+++ b/precise_bbcode/bbcode/parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 from collections import defaultdict
 

--- a/precise_bbcode/bbcode/parser.py
+++ b/precise_bbcode/bbcode/parser.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import re
 from collections import defaultdict
 

--- a/precise_bbcode/bbcode/regexes.py
+++ b/precise_bbcode/bbcode/regexes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 
 

--- a/precise_bbcode/bbcode/regexes.py
+++ b/precise_bbcode/bbcode/regexes.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
 import re
 
 

--- a/precise_bbcode/bbcode/regexes.py
+++ b/precise_bbcode/bbcode/regexes.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 import re
 
 
@@ -11,6 +15,7 @@ placeholder_content_re = re.compile(r'^(?P<placeholder_name>[a-zA-Z]+)(\d*)(=[^\
 
 
 # BBCode regexes
-bbcodde_standard_re = r'^\[(?P<start_name>[^\s=\[\]]*)(=\{[a-zA-Z]+\d*=?[^\s\[\]\{\}=]*\})?\]\{[a-zA-Z]+\d*=?[^\s\[\]\{\}=]*\}(\[/(?P<end_name>[^\s=\[\]]*)\])?$'  # noqa
+#bbcodde_standard_re = r'^\[(?P<start_name>[^\s=\[\]]*)(=\{[a-zA-Z]+\d*=?[^\s\[\]\{\}=]*\})?\]\{[a-zA-Z]+\d*=?[^\s\[\]\{\}=]*\}(\[/(?P<end_name>[^\s=\[\]]*)\])?$'  # noqa
+bbcodde_standard_re = r'^\[(?P<start_name>[^\s=\[\]]*)(=\{[a-zA-Z]+\d*=?[^\s\[\]\{\}=]*\})?(\s+(?P<named_types>\{(.*)\}=(.*)))*\]\{[a-zA-Z]+\d*=?[^\s\[\]\{\}=]*\}(\[/(?P<end_name>[^\s=\[\]]*)\])?$' # extended for named attributes
 bbcodde_standalone_re = r'^\[(?P<start_name>[^\s=\[\]]*)(=\{[a-zA-Z]+\d*=?[^\s\[\]\{\}=]*\})?\]\{?[a-zA-Z]*\d*=?[^\s\[\]\{\}=]*\}?$'  # noqa
 bbcode_content_re = re.compile(r'^\[[A-Za-z0-9]*\](?P<content>.*)\[/[A-Za-z0-9]*\]')


### PR DESCRIPTION
Hi,

I have done some work on it:
[list type=decimal]

will work with this CodeTag:
[code]
class ListBBCodeTag(BBCodeTag):
    name = 'list'

    class Options:
        transform_newlines = False
        strip = True

    def render(self, value, option=None, parent=None):
        import re
        css_opts = [
            'decimal', 'decimal-leading-zero',
            'lower-alpha', 'upper-alpha',
            'lower-roman', 'upper-roman',
        ]
        options = {}
        for match in re.finditer(r"([a-zA-Z]+)=([^\s]*)", option):
            options[match.group(1)] = match.group(2)

        list_tag = 'ol' if options["type"] in css_opts else 'ul'
        list_tag_css = ' style="list-style-type:{};"'.format(options["type"])
        rendered = '<{tag}{css}>{content}</{tag}>'.format(tag=list_tag, css=list_tag_css, content=value)
        return rendered
[/code]

and the changes I have made in my fork.
Please comment. 