### PR TITLE
Allow for URL patterns that have quotes around the url

### DIFF
--- a/precise_bbcode/bbcode/defaults/tag.py
+++ b/precise_bbcode/bbcode/defaults/tag.py
@@ -105,6 +105,10 @@ class UrlBBCodeTag(BBCodeTag):
 
     def render(self, value, option=None, parent=None):
         href = option if option else value
+        if href[0] == href[-1] and href[0] in ('"', '\'') and len(href) > 2:
+            # URLs can be encapsulated in quotes (either single or double) that aren't part of the URL. If that's the
+            # case, strip them out.
+            href = href[1:-2]
         href = replace(href, bbcode_settings.BBCODE_ESCAPE_HTML)
         if '://' not in href and self._domain_re.match(href):
             href = 'http://' + href

--- a/precise_bbcode/bbcode/defaults/tag.py
+++ b/precise_bbcode/bbcode/defaults/tag.py
@@ -106,8 +106,8 @@ class UrlBBCodeTag(BBCodeTag):
     def render(self, value, option=None, parent=None):
         href = option if option else value
         if href[0] == href[-1] and href[0] in ('"', '\'') and len(href) > 2:
-            # URLs can be encapsulated in quotes (either single or double) that aren't part of the URL. If that's the
-            # case, strip them out.
+            # URLs can be encapsulated in quotes (either single or double) that aren't part of the
+            # URL. If that's the case, strip them out.
             href = href[1:-2]
         href = replace(href, bbcode_settings.BBCODE_ESCAPE_HTML)
         if '://' not in href and self._domain_re.match(href):

--- a/precise_bbcode/bbcode/defaults/tag.py
+++ b/precise_bbcode/bbcode/defaults/tag.py
@@ -108,7 +108,7 @@ class UrlBBCodeTag(BBCodeTag):
         if href[0] == href[-1] and href[0] in ('"', '\'') and len(href) > 2:
             # URLs can be encapsulated in quotes (either single or double) that aren't part of the
             # URL. If that's the case, strip them out.
-            href = href[1:-2]
+            href = href[1:-1]
         href = replace(href, bbcode_settings.BBCODE_ESCAPE_HTML)
         if '://' not in href and self._domain_re.match(href):
             href = 'http://' + href

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -109,9 +109,9 @@ class TestParser(object):
         ('[col\nor]more tests[/color]', '[col<br />or]more tests[/color]'),
         ('[color]more tests[/color=#FFF]', '[color]more tests[/color=#FFF]'),
         ('[*]hello[/i]', '<li>hello</li>'),
-        ('[url=\'\']Hello[/url]', '[url=\'\']Hello[/url]'),  # No url in quotes (empty url)
+        ('[url=\'\']Hello[/url]', '[url=&#39;&#39;]Hello[/url]'),  # No url in quotes (empty url)
         ('[url=\'http://google.com][/url]',
-         '[url=\'http://google.com][/url]'),  # Open quote but no close in url
+         '[url=&#39;http://google.com][/url]'),  # Open quote but no close in url
         # BBCodes with semantic errors
         ('[color=some words]test[/color]', '[color=some words]test[/color]'),
         # Unknown BBCodes

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -36,7 +36,8 @@ class TestParser(object):
         ('[url=http://google.com][/url]', '<a href="http://google.com">http://google.com</a>'),
         ('[url=\'http://google.com\'][/url]', '<a href="http://google.com">http://google.com</a>'),
         ('[url="http://google.com"][/url]', '<a href="http://google.com">http://google.com</a>'),
-        ('[url=http://google.com\'][/url]', '<a href="http://google.com\'">http://google.com\'</a>'),  # Close quote but no open in url
+        ('[url=http://google.com\'][/url]',
+         '<a href="http://google.com\'">http://google.com\'</a>'),  # Close quote but no open
         ('[URL=google.com]goto google[/URL]', '<a href="http://google.com">goto google</a>'),
         (
             '[url=<script>alert(1);</script>]xss[/url]',

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -36,8 +36,6 @@ class TestParser(object):
         ('[url=http://google.com][/url]', '<a href="http://google.com">http://google.com</a>'),
         ('[url=\'http://google.com\'][/url]', '<a href="http://google.com">http://google.com</a>'),
         ('[url="http://google.com"][/url]', '<a href="http://google.com">http://google.com</a>'),
-        ('[url=http://google.com\'][/url]',
-         '<a href="http://google.com\'">http://google.com\'</a>'),  # Close quote but no open
         ('[URL=google.com]goto google[/URL]', '<a href="http://google.com">goto google</a>'),
         (
             '[url=<script>alert(1);</script>]xss[/url]',

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -112,7 +112,8 @@ class TestParser(object):
         ('[color]more tests[/color=#FFF]', '[color]more tests[/color=#FFF]'),
         ('[*]hello[/i]', '<li>hello</li>'),
         ('[url=\'\']Hello[/url]', '[url=\'\']Hello[/url]'),  # No url in quotes (empty url)
-        ('[url=\'http://google.com][/url]', '[url=\'http://google.com][/url]'),  # Open quote but no close in url
+        ('[url=\'http://google.com][/url]',
+         '[url=\'http://google.com][/url]'),  # Open quote but no close in url
         # BBCodes with semantic errors
         ('[color=some words]test[/color]', '[color=some words]test[/color]'),
         # Unknown BBCodes

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -34,6 +34,9 @@ class TestParser(object):
         ),
         ('[url=google.com]goto google[/url]', '<a href="http://google.com">goto google</a>'),
         ('[url=http://google.com][/url]', '<a href="http://google.com">http://google.com</a>'),
+        ('[url=\'http://google.com\'][/url]', '<a href="http://google.com">http://google.com</a>'),
+        ('[url="http://google.com"][/url]', '<a href="http://google.com">http://google.com</a>'),
+        ('[url=http://google.com\'][/url]', '<a href="http://google.com\'">http://google.com\'</a>'),  # Close quote but no open in url
         ('[URL=google.com]goto google[/URL]', '<a href="http://google.com">goto google</a>'),
         (
             '[url=<script>alert(1);</script>]xss[/url]',
@@ -107,6 +110,8 @@ class TestParser(object):
         ('[col\nor]more tests[/color]', '[col<br />or]more tests[/color]'),
         ('[color]more tests[/color=#FFF]', '[color]more tests[/color=#FFF]'),
         ('[*]hello[/i]', '<li>hello</li>'),
+        ('[url=\'\']Hello[/url]', '[url=\'\']Hello[/url]'),  # No url in quotes (empty url)
+        ('[url=\'http://google.com][/url]', '[url=\'http://google.com][/url]'),  # Open quote but no close in url
         # BBCodes with semantic errors
         ('[color=some words]test[/color]', '[color=some words]test[/color]'),
         # Unknown BBCodes


### PR DESCRIPTION
This PR resolves the issue identified in #31, allowing for single and double quotes around URLs to be properly parsed. This also adds tests for various scenarios including quotes. 